### PR TITLE
docs: Add branch name to the installation of the parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ parser_config.d2 = {
   install_info = {
     url = "https://github.com/ravsii/tree-sitter-d2",
     files = { "src/parser.c" },
+    branch = "main"
   },
   filetype = "d2",
 }


### PR DESCRIPTION
Without the branch name specified, then nvim-treesitter will pick the `master` branch when downloading the parser repo.
[Nvim-treesitter Ref](https://github.com/nvim-treesitter/nvim-treesitter/blob/master/lua/nvim-treesitter/shell_command_selectors.lua#L239) 

